### PR TITLE
Cant be set as author permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,20 @@ Follow standard Redmine plugin installation procedure.
 
 Configuration
 -------------
+Set following permission for roles:
 
- * Set "Edit author" permission for roles.
+ * "Edit author"
 
     Authorized users will be able to edit issue author by simply changing field
     in edit form.
+
+ * "Set original author"
+
+    Authorized users will be able to set a different issue author when creating new issue.
+
+ * "Can't be set as author"
+
+    Users with this permission can't be choosed as author.
 
 
 Requirements

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   permission_edit_issue_author: "Edit author"
   permission_set_original_issue_author: "Set original author"
+  permission_can_be_set_as_issue_author: "User can be set as author"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
 en:
   permission_edit_issue_author: "Edit author"
   permission_set_original_issue_author: "Set original author"
-  permission_can_be_set_as_issue_author: "User can be set as author"
+  permission_cant_be_set_as_issue_author: "User can not be set as author"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,3 +1,4 @@
 it:
   permission_edit_issue_author: "Modifica autore"
   permission_set_original_issue_author: "Imposta l'autore originale"
+  permission_can_be_set_as_issue_author: "L'utente può essere impostato come autore"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,4 @@
 it:
   permission_edit_issue_author: "Modifica autore"
   permission_set_original_issue_author: "Imposta l'autore originale"
-  permission_can_be_set_as_issue_author: "L'utente può essere impostato come autore"
+  permission_cant_be_set_as_issue_author: "L'utente non può essere impostato come autore"

--- a/init.rb
+++ b/init.rb
@@ -11,6 +11,7 @@ Redmine::Plugin.register :redmine_editauthor do
   project_module :issue_tracking do
     permission :edit_issue_author, {}
     permission :set_original_issue_author, {}
+    permission :can_be_set_as_issue_author, {}
   end
 end
 

--- a/init.rb
+++ b/init.rb
@@ -11,7 +11,7 @@ Redmine::Plugin.register :redmine_editauthor do
   project_module :issue_tracking do
     permission :edit_issue_author, {}
     permission :set_original_issue_author, {}
-    permission :can_be_set_as_issue_author, {}
+    permission :cant_be_set_as_issue_author, {}
   end
 end
 

--- a/lib/redmine_editauthor/hook.rb
+++ b/lib/redmine_editauthor/hook.rb
@@ -58,7 +58,7 @@ module RedmineEditauthor
         User.active.eager_load(:members).where(
           "#{Member.table_name}.project_id = ? OR #{User.table_name}.admin = ?",
           project.id, true
-        ).select { |u| u.allowed_to?(:add_issues, project) }
+        ).select { |u| u.allowed_to?(:can_be_set_as_issue_author, project) } # permission filter
       end
 
       def author_select_field(options)

--- a/lib/redmine_editauthor/hook.rb
+++ b/lib/redmine_editauthor/hook.rb
@@ -58,7 +58,7 @@ module RedmineEditauthor
         User.active.eager_load(:members).where(
           "#{Member.table_name}.project_id = ? OR #{User.table_name}.admin = ?",
           project.id, true
-        ).select { |u| u.allowed_to?(:can_be_set_as_issue_author, project) } # permission filter
+        ).select { |u| u.allowed_to?(:add_issues, project) && !u.allowed_to?(:cant_be_set_as_issue_author, project) }
       end
 
       def author_select_field(options)


### PR DESCRIPTION
When setting a new author I need that some users are not selectable. So I added a new switch with `:cant_be_set_as_issue_author` permission that is used when evaluating if a user should be displayed in the list.